### PR TITLE
Point production pipeline to pypi(not test)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
           ls -al dist/
 
       - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
-        name: Publish to Test PyPI
+        name: Publish to Production PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository_url: https://pypi.org/legacy/


### PR DESCRIPTION
Release pipeline pointed to test.pypi.org.
Fixing for actual release.