### PR TITLE
Change URL for Pypi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-          repository_url: https://pypi.org/legacy/
+          repository_url: https://pypi.org/project/nvidia-clara-cpost/


### PR DESCRIPTION
For test publication -- we need to push to test.pypi.org, but for actual release, the pipeline needs to point to https://pypi.org/project/nvidia-clara-cpost/